### PR TITLE
feat: fix build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "test": "pnpm -r test",
     "test:watch": "pnpm -r test:watch",
     "test:coverage": "pnpm -r test:coverage",
-    "preinstall": "npx only-allow pnpm",
-    "prepare": "husky || true"
+    "preinstall": "pnpm --filter @ogcio/consent preinstall",
+    "prepare": "pnpm --filter @ogcio/consent prepare",
+    "prepublishOnly": "pnpm --filter @ogcio/consent prepublishOnly"
   },
   "keywords": [
     "consent",

--- a/packages/consent/package.json
+++ b/packages/consent/package.json
@@ -33,7 +33,10 @@
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "prepublishOnly": "pnpm i && pnpm build && pnpm test",
+    "preinstall": "npx only-allow pnpm",
+    "prepare": "husky || true"
   },
   "keywords": [
     "consent",


### PR DESCRIPTION
## PR Description: Fix Build Scripts

This PR addresses build script configuration issues in the monorepo by properly delegating package lifecycle hooks to the consent package.

### Changes Made

**Root package.json (`/package.json`):**
- **Modified `preinstall` script**: Changed from global `npx only-allow pnpm` to `pnpm --filter @ogcio/consent preinstall` to delegate to the consent package
- **Modified `prepare` script**: Changed from global `husky || true` to `pnpm --filter @ogcio/consent prepare` to delegate to the consent package  
- **Added `prepublishOnly` script**: New script `pnpm --filter @ogcio/consent prepublishOnly` to delegate publishing preparation to the consent package

**Consent package.json (`/packages/consent/package.json`):**
- **Added `prepublishOnly` script**: New comprehensive pre-publish workflow: `pnpm i && pnpm build && pnpm test` that ensures dependencies are installed, the package is built, and tests pass before publishing
- **Added `preinstall` script**: `npx only-allow pnpm` to enforce pnpm usage (moved from root)
- **Added `prepare` script**: `husky || true` for git hooks setup (moved from root)

### Purpose

This restructuring ensures that:
1. **Package-specific lifecycle hooks** are properly scoped to the `@ogcio/consent` package rather than running globally
2. **Publishing safety** is improved with the new `prepublishOnly` script that validates the package before publication
3. **Monorepo structure** is better organized with proper delegation of responsibilities
4. **Build consistency** is maintained across different environments

The changes fix potential issues where monorepo-level scripts might interfere with package-specific operations and ensure that the consent package can be properly built and published independently.